### PR TITLE
make compiation errors in test files real errors instead of failing s…

### DIFF
--- a/lib/runner/filematcher.js
+++ b/lib/runner/filematcher.js
@@ -31,15 +31,7 @@ module.exports = {
      * @returns {boolean} true if specified test matches given tag
      */
     match : function (testFilePath, opts) {
-      var test;
-
-      try {
-        test = require(testFilePath);
-      } catch (e) {
-        // could not load test module
-        return false;
-      }
-
+      var test = require(testFilePath);
       return this.checkModuleTags(test, opts);
     },
 


### PR DESCRIPTION
currently, if a test has a syntax error it is silently ignored. no output gets reported for that test, so jenkins isn't aware of the failure. this issue was fixed in nightwatch with https://github.com/nightwatchjs/nightwatch/issues/1068. incorporating that fix into our version.